### PR TITLE
Remove double SSO request when redirected from Discourse

### DIFF
--- a/src/app/Http/Controllers/LoginController.php
+++ b/src/app/Http/Controllers/LoginController.php
@@ -4,15 +4,15 @@ namespace App\Http\Controllers;
 
 use App\Library\Discourse\Authentication\DiscourseLoginHandler;
 use App\Library\Discourse\Exceptions\BadSSOPayloadException;
+use App\Entities\Accounts\Repositories\AccountRepository;
 use App\Services\Login\LogoutService; 
 use App\Http\Requests\LoginRequest;
+use App\Http\WebController;
+use App\Environment;
 use Illuminate\Contracts\Auth\Guard as Auth;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
-use \Illuminate\View\View;
-use App\Environment;
-use App\Entities\Accounts\Repositories\AccountRepository;
-use App\Http\WebController;
+use Illuminate\View\View;
 use Illuminate\Support\Facades\Log;
 
 final class LoginController extends WebController
@@ -64,6 +64,7 @@ final class LoginController extends WebController
         {
             $account  = $this->auth->user();
             $endpoint = $this->discourseLoginHandler->getRedirectUrl(
+                $request,
                 $account->getKey(), 
                 $account->email
             );

--- a/src/app/Library/Discourse/Api/DiscourseSSOApi.php
+++ b/src/app/Library/Discourse/Api/DiscourseSSOApi.php
@@ -18,7 +18,7 @@ class DiscourseSSOApi extends DiscourseAPIRequest
      *
      * @return DiscoursePackedNonce
      */
-    public function requestPackedNonce(string $returnPath = '/latest') : DiscoursePackedNonce
+    public function requestNewPackedNonce(string $returnPath = '/latest') : DiscoursePackedNonce
     {
         $response = $this->client->get('session/sso?return_path='.$returnPath, [
             'allow_redirects' => [

--- a/src/app/Library/Discourse/Authentication/DiscourseLoginHandler.php
+++ b/src/app/Library/Discourse/Authentication/DiscourseLoginHandler.php
@@ -62,7 +62,7 @@ final class DiscourseLoginHandler
         // if the SSO and Signature parameters aren't present, it means the user has tapped the login button from
         // the PCB side. In this situation, we'll hit the Discourse SSO URL on the user's behalf to retrieve the
         // SSO and Signature parameter, so the user doesn't have to go through a double redirect (PCB -> Forum -> PCB)
-        return $this->ssoApi->requestPackedNonce();
+        return $this->ssoApi->requestNewPackedNonce();
     }
     
     /**

--- a/src/app/Library/Discourse/Authentication/DiscourseLoginHandler.php
+++ b/src/app/Library/Discourse/Authentication/DiscourseLoginHandler.php
@@ -6,6 +6,8 @@ use App\Library\Discourse\Exceptions\BadSSOPayloadException;
 use App\Library\Discourse\Entities\DiscourseNonce;
 use App\Library\Discourse\Entities\DiscoursePayload;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Http\Request;
+use App\Library\Discourse\Entities\DiscoursePackedNonce;
 
 final class DiscourseLoginHandler
 {
@@ -28,9 +30,9 @@ final class DiscourseLoginHandler
         $this->payloadValidator = $payloadValidator;
     }
 
-    public function getRedirectUrl(int $pcbId, string $email)
+    public function getRedirectUrl(Request $request, int $pcbId, string $email)
     {
-        $packedNonce = $this->ssoApi->requestPackedNonce();
+        $packedNonce = $this->getPackedNonce($request);
 
         $nonce = $this->decodePackedNonce(
             $packedNonce->getSSO(), 
@@ -42,6 +44,25 @@ final class DiscourseLoginHandler
             $nonce->getNonce(), 
             $nonce->getRedirectUri()
         );
+    }
+
+    private function getPackedNonce(Request $request) : DiscoursePackedNonce
+    {
+        // if the user pressed the login button from the Discourse side or attempted an authenticated action
+        // (eg. replying), Discourse will automatically redirect the user to our login page with an SSO and 
+        // Signature parameter in the URL
+        if ($request->has('sso') && $request->has('sig'))
+        {
+            return new DiscoursePackedNonce(
+                $request->get('sso'), 
+                $request->get('sig')
+            );
+        }
+
+        // if the SSO and Signature parameters aren't present, it means the user has tapped the login button from
+        // the PCB side. In this situation, we'll hit the Discourse SSO URL on the user's behalf to retrieve the
+        // SSO and Signature parameter, so the user doesn't have to go through a double redirect (PCB -> Forum -> PCB)
+        return $this->ssoApi->requestPackedNonce();
     }
     
     /**


### PR DESCRIPTION
Currently the login page makes a call to the Discourse SSO API to retrieve an `sso` and `sig` parameter. However, if the user is redirected to our login page from Discourse, the URL will already contain the `sso` and `sig` parameter.

This PR prevents the unnecessary SSO API request if the parameters are given to the login page.