### PR TITLE
Force Discourse login after registration

### DIFF
--- a/src/app/Entities/Accounts/Models/Account.php
+++ b/src/app/Entities/Accounts/Models/Account.php
@@ -7,74 +7,57 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\URL;
 use App\Entities\Groups\Models\Group;
+use App\Entities\Players\Models\MinecraftPlayer;
 
-/**
- * App\Entities\Accounts\Models\Account
- *
- * @property int $account_id
- * @property string $email
- * @property string $password
- * @property string|null $remember_token
- * @property string|null $last_login_ip
- * @property \Illuminate\Support\Carbon|null $last_login_at
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \Illuminate\Database\Eloquent\Collection|\App\Entities\Groups\Models\Group[] $groups
- * @property-read \Illuminate\Database\Eloquent\Collection|\App\Entities\Accounts\Models\AccountLink[] $linkedSocialAccounts
- * @property-read \App\Entities\Players\Models\MinecraftPlayer $minecraftAccount
- * @property-read \Illuminate\Notifications\DatabaseNotificationCollection|\Illuminate\Notifications\DatabaseNotification[] $notifications
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account query()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account whereAccountId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account whereEmail($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account whereLastLoginAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account whereLastLoginIp($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account wherePassword($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account whereRememberToken($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\Account whereUpdatedAt($value)
- * @mixin \Eloquent
- */
-class Account extends Authenticatable
+final class Account extends Authenticatable
 {
     use Notifiable;
 
-    protected $table = 'accounts';
+    public const TABLE_NAME = 'accounts';
 
-    protected $primaryKey = 'account_id';
+    public const COLUMN_ACCOUNT_ID = 'account_id';
+    public const COLUMN_EMAIL = 'email';
+    public const COLUMN_PASSWORD = 'password';
+    public const COLUMN_REMEMBER_TOKEN = 'remember_token';
+    public const COLUMN_LAST_LOGIN_IP = 'last_login_ip';
+    public const COLUMN_LAST_LOGIN_AT = 'last_login_at';
+
+
+    protected $table = self::TABLE_NAME;
+    protected $primaryKey = self::COLUMN_ACCOUNT_ID;
 
     protected $fillable = [
-        'email',
-        'password',
-        'remember_token',
-        'last_login_ip',
-        'last_login_at',
+        self::COLUMN_EMAIL,
+        self::COLUMN_PASSWORD,
+        self::COLUMN_REMEMBER_TOKEN,
+        self::COLUMN_LAST_LOGIN_IP,
+        self::COLUMN_LAST_LOGIN_AT,
     ];
 
     protected $hidden = [
-
+        self::COLUMN_PASSWORD,
+        self::COLUMN_REMEMBER_TOKEN,
+        self::COLUMN_LAST_LOGIN_IP,
     ];
 
     protected $dates = [
-        'created_at',
-        'updated_at',
-        'last_login_at',
+        self::COLUMN_LAST_LOGIN_AT,
     ];
 
+    
     public function minecraftAccount()
     {
-        return $this->belongsTo('App\Entities\Players\Models\MinecraftPlayer', 'account_id', 'account_id');
+        return $this->belongsTo(MinecraftPlayer::class, self::COLUMN_ACCOUNT_ID, self::COLUMN_ACCOUNT_ID);
     }
 
     public function linkedSocialAccounts()
     {
-        return $this->hasMany('App\Entities\Accounts\Models\AccountLink', 'account_id', 'account_id');
+        return $this->hasMany(AccountLink::class, self::COLUMN_ACCOUNT_ID, self::COLUMN_ACCOUNT_ID);
     }
 
     public function groups()
     {
-        return $this->belongsToMany(Group::class, 'groups_accounts', 'account_id', 'group_id');
+        return $this->belongsToMany(Group::class, 'groups_accounts', self::COLUMN_ACCOUNT_ID, 'group_id');
     }
 
     /**

--- a/src/app/Entities/Accounts/Models/AccountEmailChange.php
+++ b/src/app/Entities/Accounts/Models/AccountEmailChange.php
@@ -5,37 +5,9 @@ namespace App\Entities\Accounts\Models;
 use App\Model;
 use Illuminate\Support\Facades\URL;
 
-/**
- * App\Entities\Accounts\Models\AccountEmailChange
- *
- * @property int $account_email_change_id
- * @property int $account_id
- * @property string $token
- * @property string $email_previous
- * @property string $email_new
- * @property mixed $is_previous_confirmed
- * @property mixed $is_new_confirmed
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \App\Entities\Accounts\Models\Account $account
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange query()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereAccountEmailChangeId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereAccountId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereEmailNew($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereEmailPrevious($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereIsNewConfirmed($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereIsPreviousConfirmed($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereToken($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountEmailChange whereUpdatedAt($value)
- * @mixin \Eloquent
- */
-class AccountEmailChange extends Model
+final class AccountEmailChange extends Model
 {
     protected $table = 'account_email_changes';
-
     protected $primaryKey = 'account_email_change_id';
 
     protected $fillable = [
@@ -47,17 +19,10 @@ class AccountEmailChange extends Model
         'is_new_confirmed',
     ];
 
-    protected $hidden = [
-    ];
-
-    protected $dates = [
-        'created_at',
-        'updated_at',
-    ];
 
     public function account()
     {
-        return $this->belongsTo('App\Entities\Accounts\Models\Account', 'account_id', 'account_id');
+        return $this->belongsTo(Account::class, Account::COLUMN_ACCOUNT_ID, Account::COLUMN_ACCOUNT_ID);
     }
 
     public function getCurrentEmailUrl(int $expiryInMins = 20)

--- a/src/app/Entities/Accounts/Models/AccountLink.php
+++ b/src/app/Entities/Accounts/Models/AccountLink.php
@@ -4,30 +4,7 @@ namespace App\Entities\Accounts\Models;
 
 use App\Model;
 
-/**
- * App\Entities\Accounts\Models\AccountLink
- *
- * @property int $account_link_id
- * @property int $account_id
- * @property string|null $provider_name
- * @property string|null $provider_id
- * @property string $provider_email
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \App\Entities\Accounts\Models\Account $account
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink query()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink whereAccountId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink whereAccountLinkId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink whereProviderEmail($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink whereProviderId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink whereProviderName($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountLink whereUpdatedAt($value)
- * @mixin \Eloquent
- */
-class AccountLink extends Model
+final class AccountLink extends Model
 {
     protected $table = 'account_links';
 

--- a/src/app/Entities/Accounts/Models/AccountPasswordReset.php
+++ b/src/app/Entities/Accounts/Models/AccountPasswordReset.php
@@ -5,21 +5,7 @@ namespace App\Entities\Accounts\Models;
 use App\Model;
 use Illuminate\Support\Facades\URL;
 
-/**
- * App\Entities\Accounts\Models\AccountPasswordReset
- *
- * @property string $email
- * @property string $token
- * @property \Illuminate\Support\Carbon|null $created_at
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountPasswordReset newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountPasswordReset newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountPasswordReset query()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountPasswordReset whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountPasswordReset whereEmail($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\AccountPasswordReset whereToken($value)
- * @mixin \Eloquent
- */
-class AccountPasswordReset extends Model
+final class AccountPasswordReset extends Model
 {
     protected $table = 'account_password_resets';
 

--- a/src/app/Entities/Accounts/Models/UnactivatedAccount.php
+++ b/src/app/Entities/Accounts/Models/UnactivatedAccount.php
@@ -6,26 +6,7 @@ use App\Model;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Notifications\Notifiable;
 
-/**
- * App\Entities\Accounts\Models\UnactivatedAccount
- *
- * @property int $unactivated_account_id
- * @property string $email
- * @property string $password
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \Illuminate\Notifications\DatabaseNotificationCollection|\Illuminate\Notifications\DatabaseNotification[] $notifications
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\UnactivatedAccount newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\UnactivatedAccount newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\UnactivatedAccount query()
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\UnactivatedAccount whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\UnactivatedAccount whereEmail($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\UnactivatedAccount wherePassword($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\UnactivatedAccount whereUnactivatedAccountId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Entities\Accounts\Models\UnactivatedAccount whereUpdatedAt($value)
- * @mixin \Eloquent
- */
-class UnactivatedAccount extends Model
+final class UnactivatedAccount extends Model
 {
     use Notifiable;
 

--- a/src/app/Http/Controllers/DonationController.php
+++ b/src/app/Http/Controllers/DonationController.php
@@ -65,8 +65,7 @@ class DonationController extends WebController
 
     public function getView()
     {
-        abort(503);
-        // return view('front.pages.donate.donate');
+        return view('front.pages.donate.donate');
     }
 
     public function donate(Request $request)

--- a/src/app/Http/Controllers/LoginController.php
+++ b/src/app/Http/Controllers/LoginController.php
@@ -54,12 +54,23 @@ final class LoginController extends WebController
      * @param Request $request
      * @return RedirectResponse|View
      */
-    public function loginOrShowForm(Request $request)
+    public function showLoginForm(Request $request)
     {
-        if ($this->auth->check() === false) 
+        if ($this->auth->check() === true) 
         {
-            return view('front.pages.login.login');
+            return response()->redirectToRoute('front.home');
         }
+        return view('front.pages.login.login');
+    }
+
+    /**
+     * Handles a login request sent from the login form
+     *
+     * @param LoginRequest $request
+     * @return RedirectResponse|View
+     */
+    public function login(LoginRequest $request)
+    {
         try 
         {
             $account  = $this->auth->user();
@@ -83,17 +94,6 @@ final class LoginController extends WebController
     }
 
     /**
-     * Handles a login request sent from the login form
-     *
-     * @param LoginRequest $request
-     * @return RedirectResponse|View
-     */
-    public function login(LoginRequest $request)
-    {
-        return $this->loginOrShowForm($request);
-    }
-
-    /**
      * Logs out the current PCB account
      *
      * (called from Discourse)
@@ -109,8 +109,7 @@ final class LoginController extends WebController
     }
 
     /**
-     * Logs out the current PCB account and
-     * its associated Discourse account
+     * Logs out the current PCB account and its associated Discourse account
      *
      * (called from this site)
      *

--- a/src/app/Http/Controllers/RegisterController.php
+++ b/src/app/Http/Controllers/RegisterController.php
@@ -6,16 +6,19 @@ use App\Entities\Accounts\Repositories\AccountRepository;
 use App\Entities\Accounts\Repositories\UnactivatedAccountRepository;
 use App\Entities\Accounts\Notifications\AccountActivationNotification;
 use App\Http\Requests\RegisterRequest;
-use Illuminate\Database\Connection;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 use Carbon\Carbon;
 use Hash;
 use App\Http\WebController;
+use App\Entities\Accounts\Models\Account;
+use Illuminate\Support\Facades\DB;
+use App\Library\Discourse\Authentication\DiscourseLoginHandler;
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Log;
 
-class RegisterController extends WebController
+final class RegisterController extends WebController
 {
-
     /**
      * @var AccountRepository
      */
@@ -27,19 +30,26 @@ class RegisterController extends WebController
     private $unactivatedAccountRepository;
 
     /**
-     * @var Connection
+     * @var DiscourseLoginHandler
      */
-    private $connection;
+    private $discourseLoginHandler;
+
+    /**
+     * @var CLient
+     */
+    private $client;
 
 
     public function __construct(
         AccountRepository $accountRepository,
         UnactivatedAccountRepository $unactivatedAccountRepository,
-        Connection $connection
+        DiscourseLoginHandler $discourseLoginHandler,
+        Client $client
     ) {
         $this->accountRepository = $accountRepository;
         $this->unactivatedAccountRepository = $unactivatedAccountRepository;
-        $this->connection = $connection;
+        $this->discourseLoginHandler = $discourseLoginHandler;
+        $this->client = $client;
     }
 
     public function showRegisterView()
@@ -62,7 +72,8 @@ class RegisterController extends WebController
     }
 
     /**
-     * Attempts to activate an account via token
+     * Finishes the registration process by attempting to activate the account that 
+     * belongs to the given email address
      *
      * @param Request $request
      *
@@ -71,40 +82,83 @@ class RegisterController extends WebController
      */
     public function activate(Request $request)
     {
+        // payload is signed to prevent tampering, so this URL parameter is safe to use as it is
         $email = $request->get('email');
-        if (empty($email)) {
+        
+        if (empty($email)) 
+        {
             return view('front.pages.register.register');
         }
 
         $unactivatedAccount = $this->unactivatedAccountRepository->getByEmail($email);
-        if ($unactivatedAccount === null) {
+        if ($unactivatedAccount === null) 
+        {
             // TODO: inform user that account does not exist
-            abort(404);
+            abort(404, 'Account does not exist');
         }
 
-        $accountByEmail = $this->accountRepository->getByEmail($email);
-        if ($accountByEmail) {
+        $account = $this->accountRepository->getByEmail($email);
+        if ($account) 
+        {
             // TODO: inform user account is already activated
-            abort(410);
+            abort(410, 'Account already activated');
         }
 
-        $this->connection->beginTransaction();
-        try {
-            $this->accountRepository->create(
+        DB::beginTransaction();
+        try 
+        {
+            $account = $this->accountRepository->create(
                 $unactivatedAccount->email,
                 $unactivatedAccount->password,
                 $request->ip(),
                 Carbon::now()
             );
-
             $unactivatedAccount->delete();
 
-            $this->connection->commit();
-        } catch (\Exception $e) {
-            $this->connection->rollBack();
+            DB::commit();
+        } 
+        catch (\Exception $e) 
+        {
+            DB::rollBack();
             throw $e;
         }
 
+        // Login to Discourse on behalf of the user, server-side, to force Discourse to create an account
+        // for the user and therefore stay in sync with PCB. This step is necessary because some users 
+        // register an account but never login once afterwards, which means they'l have a PCB account but 
+        // not a forum account, and this causes all sorts of nasty problems later
+        $this->forceLoginServerSide($request, $account);
+
         return view('front.pages.register.register-verify-complete');
+    }
+
+    /**
+     * Logs-in to Discourse on behalf of the user, server-side
+     *
+     * @param Request $request
+     * @param Account $account
+     * @return void
+     */
+    private function forceLoginServerSide(Request $request, Account $account)
+    {
+        if (Environment::isDev())
+        {
+            return;
+        }
+        try 
+        {
+            $endpoint = $this->discourseLoginHandler->getRedirectUrl(
+                $request,
+                $account->getKey(), 
+                $account->email
+            );
+            
+            $this->client->get($endpoint);
+        } 
+        catch (BadSSOPayloadException $e) 
+        {
+            Log::debug('Missing nonce or return key in session', ['session' => $request->session()]);
+            throw $e;
+        }
     }
 }

--- a/src/app/Http/Controllers/RegisterController.php
+++ b/src/app/Http/Controllers/RegisterController.php
@@ -123,10 +123,13 @@ final class RegisterController extends WebController
             throw $e;
         }
 
-        // Login to Discourse on behalf of the user, server-side, to force Discourse to create an account
-        // for the user and therefore stay in sync with PCB. This step is necessary because some users 
-        // register an account but never login once afterwards, which means they'l have a PCB account but 
-        // not a forum account, and this causes all sorts of nasty problems later
+        // Login to Discourse on behalf of the user to force Discourse to create an account for the user. 
+        // This step is necessary because some users register an account but never login once afterwards, 
+        // which means they'll have a PCB account but not a forum account, and this causes all sorts of 
+        // nasty problems later.
+        //
+        // This step doesn't actually log the user in, because the server is making the request on behalf
+        // of the user.
         $this->forceLoginServerSide($request, $account);
 
         return view('front.pages.register.register-verify-complete');

--- a/src/resources/views/front/pages/register/register-verify-complete.blade.php
+++ b/src/resources/views/front/pages/register/register-verify-complete.blade.php
@@ -11,11 +11,6 @@
             <p>
                 Thank you for registering. Your account is now active.
             </p>
-
-            <a class="button button--large button--primary" href="https://forums.projectcitybuild.com/login">
-                <i class="fas fa-chevron-right"></i>
-                Go to Login Screen
-            </a>
         </div>
 
     </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -64,7 +64,7 @@ Route::get('donations', [
 Route::prefix('login')->group(function () {
     Route::get('/', [
         'as'    => 'front.login',
-        'uses'  => 'LoginController@loginOrShowForm',
+        'uses'  => 'LoginController@showLoginForm',
     ]);
     Route::post('/', [
         'as'    => 'front.login.submit',


### PR DESCRIPTION
## Background
If the user registers but does not login to Discourse at least once, they won't actually have a Discourse account (and there is no Discourse API endpoint to create one either).

## Solution
This PR fixes that by logging-in on the user's behalf immediately after they register. This forces Discourse to create an account for them without actually logging them in.