### PR TITLE
Hide image meta

### DIFF
--- a/src/public/assets/css/app.css
+++ b/src/public/assets/css/app.css
@@ -2175,6 +2175,10 @@ table.table tr.disabled {
   vertical-align: middle;
 }
 
+.article .meta {
+  display: none;
+}
+
 .article__author {
   font-size: 0.7em;
   color: #c0b6b6;

--- a/src/resources/sass/pages/_home.scss
+++ b/src/resources/sass/pages/_home.scss
@@ -65,6 +65,10 @@
         }
     }
 
+    .meta {
+        display: none;
+    }
+
     &__author {
         font-size: 0.7em;
         color: #c0b6b6;


### PR DESCRIPTION
Hides image meta from the announcements page. It can _totally_ break things. It'd be ideal if we could release this immediately.