### PR TITLE
Fix code coverage percentage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+ignore:
+  - "src/app/Entities"
+  - "src/app/Exceptions"
+  - "src/app/Providers"
+  - "src/bootstrap"
+  - "src/config"
+  - "src/database"
+  - "src/public"
+  - "src/resources"
+  - "src/routes"


### PR DESCRIPTION
Omits entities (models, etc), Laravel bootstrap related classes, etc from the calculated code coverage percentage