### PR TITLE
Remove closure routes

### DIFF
--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -13,7 +13,7 @@ use App\Entities\Environment;
 |
 */
 
-// force all web routes to load over https
+// Force all web routes to load over https
 if (Environment::isProduction()) {
     URL::forceScheme('https');
 }
@@ -25,19 +25,9 @@ Route::redirect('terms', 'https://forums.projectcitybuild.com/t/community-rules/
 Route::redirect('privacy', 'https://forums.projectcitybuild.com/privacy')->name('privacy');
 
 /**
- * Sentry test route
- */
-Route::get('sentry/test', function () {
-    throw new \Exception('Sentry test');
-});
-
-/**
  * Style guide
  */
-Route::get('ui', function () {
-    return view('stylesheet');
-});
-
+Route::view('ui', 'stylesheet');
 
 
 Route::get('/', [


### PR DESCRIPTION
## Overview of Changes
Removes any closure routes. Closure routes cannot be serialized, therefore they can't be cached either and this causes `php artisan routes:cache` to fail when deploying


## Additional Information
### Deployment Steps (Optional)
`php artisan routes:cache` is now possible

### Dependencies (Optional)
None

### Screenshots (Optional)
|Before|After|
|--|--|
|||