### PR TITLE
Change go to login screen link to sso endpoint

### DIFF
--- a/src/resources/views/front/pages/password-reset/password-reset-success.blade.php
+++ b/src/resources/views/front/pages/password-reset/password-reset-success.blade.php
@@ -10,7 +10,7 @@
             <h1>Password Reset</h1>
             <p>Your password has successfully been reset. Please proceed to the login screen to complete the process.</p>
 
-            <a class="button button--large button--primary" href="https://forums.projectcitybuild.com/login">
+            <a class="button button--large button--primary" href="{{ route('front.sso.discourse') }}">
                 <i class="fas fa-chevron-right"></i>
                 Go to Login Screen
             </a>


### PR DESCRIPTION
Fixes #191

## Overview of Changes
* Changes the "go to login screen" link on the confirm page to point directly to the SSO endpoint rather than the very obviously redirecting forum login route