### PR TITLE
Strip hyphens from bans, unbans and ban status checks

### DIFF
--- a/src/app/Services/PlayerBans/PlayerBanLookupService.php
+++ b/src/app/Services/PlayerBans/PlayerBanLookupService.php
@@ -30,6 +30,11 @@ final class PlayerBanLookupService
 
     public function getStatus(GamePlayerType $playerType, string $identifier)
     {
+        if ($playerType->valueOf() === GamePlayerType::Minecraft) {
+            // Strip hyphens from Minecraft UUIDs
+            $identifier = str_replace('-', '', $identifier);
+        }
+
         $player = $this->playerLookupService->getOrCreatePlayer($playerType, $identifier);
         
         return $this->gameBanRepository->getActiveBanByGameUserId($player->getKey(), $playerType);

--- a/src/app/Services/PlayerBans/PlayerBanService.php
+++ b/src/app/Services/PlayerBans/PlayerBanService.php
@@ -61,6 +61,11 @@ final class PlayerBanService
            throw new UnauthorisedKeyActionException('limited_key', 'This server key does not have permission to create global bans');
        }
 
+       if ($bannedPlayerType->valueOf() === GamePlayerType::Minecraft) {
+           // Strip hyphens from Minecraft UUIDs
+           $bannedPlayerId = str_replace('-', '', $bannedPlayerId);
+       }
+
         $bannedPlayer = $this->playerLookupService->getOrCreatePlayer($bannedPlayerType, $bannedPlayerId);
         $staffPlayer  = $this->playerLookupService->getOrCreatePlayer($staffPlayerType, $staffPlayerId);
         
@@ -90,6 +95,11 @@ final class PlayerBanService
         string $staffPlayerId,
         GamePlayerType $staffPlayerType
     ) : GameUnban {
+        if ($bannedPlayerType->valueOf() === GamePlayerType::Minecraft) {
+            // Strip hyphens from Minecraft UUIDs
+            $bannedPlayerId = str_replace('-', '', $bannedPlayerId);
+        }
+
         $bannedPlayer = $this->playerLookupService->getOrCreatePlayer($bannedPlayerType, $bannedPlayerId);
         $staffPlayer  = $this->playerLookupService->getOrCreatePlayer($staffPlayerType, $staffPlayerId);
         


### PR DESCRIPTION
## Overview of Changes
Forgot to strip hyphens from Minecraft UUIDs when banning, unbanning a player, as well as when looking up the status of a player.

## Additional Information
### Deployment Steps (Optional)
None