### PR TITLE
Fix incorrect unban request parameters

### DIFF
--- a/src/app/Http/Controllers/Api/GameBanController.php
+++ b/src/app/Http/Controllers/Api/GameBanController.php
@@ -128,8 +128,8 @@ final class GameBanController extends ApiController
         $this->validateRequest($request->all(), [
             'player_id_type'    => ['required', Rule::in($this->getIdTypeWhitelist())],
             'player_id'         => 'required',
-            'banner_id_type'    => ['required', Rule::in($this->getIdTypeWhitelist())],
-            'banner_id'         => 'required',
+            'staff_id_type'     => ['required', Rule::in($this->getIdTypeWhitelist())],
+            'staff_id'          => 'required',
         ], [
             'in' => 'Invalid :attribute given. Must be ['.$this->getIdTypeWhitelist().']',
         ]);


### PR DESCRIPTION
## Overview of Changes
PCBridge's `/unban` command is failing because the unban request parameters should be `staff_id` and `staff_id_type`, instead of `banner_id` and `banner_id_type`