### PR TITLE
Reduce UUID lookup batch chunk to 10

### DIFF
--- a/src/app/Library/Mojang/Api/MojangPlayerApi.php
+++ b/src/app/Library/Mojang/Api/MojangPlayerApi.php
@@ -81,7 +81,7 @@ class MojangPlayerApi
      * Retrieves UUIDs for every name in the given array, in a
      * single lookup.
      *
-     * The API only allows a max of 100 names per lookup.
+     * The API only allows a max of 10 names per lookup.
      *
      * @param array $names
      *
@@ -91,8 +91,8 @@ class MojangPlayerApi
      */
     public function getUuidBatchOf(array $names) : ?array
     {
-        if (count($names) === 0 || count($names) > 100) {
-            throw new \Exception('Batch must contain between 1 and 100 names to search');
+        if (count($names) === 0 || count($names) > 10) {
+            throw new \Exception('Batch must contain between 1 and 10 names to search');
         }
 
         // Check for invalid names before hitting the api, or else

--- a/src/app/Library/QueryPlayer/GameAdapters/MojangUuidAdapter.php
+++ b/src/app/Library/QueryPlayer/GameAdapters/MojangUuidAdapter.php
@@ -33,8 +33,8 @@ final class MojangUuidAdapter implements PlayerQueryAdapterContract
     public function getUniqueIdentifiers(array $aliases = []) : array
     {
         // Split names into chunks since the Mojang API
-        // won't allow more than 100 names in a batch at once
-        $names = collect($aliases)->chunk(100);
+        // won't allow more than 10 names in a batch at once
+        $names = collect($aliases)->chunk(10);
 
         $players = [];
         foreach ($names as $nameChunk) {


### PR DESCRIPTION
## Overview of Changes
Mojang API has changed and now only accepts a maximum of 10 UUIDs in a batch lookup request (used to be 100)


## Additional Information
### Deployment Steps (Optional)
None