### PR TITLE
Registration Intent Redirect

### DIFF
--- a/src/app/Http/Controllers/RegisterController.php
+++ b/src/app/Http/Controllers/RegisterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Entities\Accounts\Notifications\AccountActivationNotification;
 use App\Entities\Accounts\Repositories\AccountRepository;
+use App\Entities\Groups\Models\Group;
 use App\Http\Actions\AccountRegistration\ActivateUnverifiedAccount;
 use App\Http\Requests\RegisterRequest;
 use App\Http\WebController;
@@ -29,6 +30,10 @@ final class RegisterController extends WebController
         $input = $request->validated();
 
         $account = $accountRepository->create($input['email'], $input['username'], $input['password'], $request->ip());
+
+        $defaultGroups = Group::where('is_default', 1)->get()->pluck('group_id');
+
+        $account->groups()->attach($defaultGroups);
 
         $account->notify(new AccountActivationNotification($account));
 

--- a/src/app/Http/Controllers/RegisterController.php
+++ b/src/app/Http/Controllers/RegisterController.php
@@ -12,8 +12,15 @@ use Illuminate\View\View;
 
 final class RegisterController extends WebController
 {
-    public function showRegisterView()
+    public function showRegisterView(Request $request)
     {
+        if ($request->session()->has('url.intended')) {
+            return response()->view('front.pages.register.register')->cookie(
+                'intended',
+                $request->session()->get('url.intended'),
+                60);
+        }
+
         return view('front.pages.register.register');
     }
 
@@ -49,6 +56,12 @@ final class RegisterController extends WebController
             $email,
             $request->ip()
         );
+
+        if ($request->cookies->has('intended')) {
+            $intended = $request->cookies->get('intended');
+            $request->cookies->remove('intended');
+            return redirect($intended);
+        }
 
         return view('front.pages.register.register-verify-complete');
     }

--- a/src/tests/Feature/RegisterTest.php
+++ b/src/tests/Feature/RegisterTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 
 
 use App\Entities\Accounts\Models\Account;
+use App\Entities\Groups\Models\Group;
 use Tests\TestCase;
 
 class RegisterTest extends TestCase
@@ -57,6 +58,26 @@ class RegisterTest extends TestCase
         $this->assertDatabaseMissing('accounts', [
             'email' => $unactivatedAccount->email,
             'password' => $unactivatedAccount->password
+        ]);
+    }
+
+    public function testNewMemberIsPutInDefaultGroup()
+    {
+        $memberGroup = Group::create([
+            'name' => 'member',
+            'is_default' => 1
+        ]);
+
+        $unactivatedAccount = factory(Account::class)->states('unhashed', 'with-confirm', 'unactivated')->make();
+
+        $this->post(route('front.register.submit'), $unactivatedAccount->toArray())
+            ->assertSessionHasNoErrors();
+
+        $account = Account::where('email', $unactivatedAccount["email"])->firstOrFail();
+
+        $this->assertDatabaseHas('groups_accounts', [
+            'group_id' => $memberGroup->group_id,
+            'account_id' => $account->account_id
         ]);
     }
 }


### PR DESCRIPTION
When a user confirms their email they're redirected back to their original intent which automatically requests they log in.

TODO: Flash notifications

Fixes #220 