### PR TITLE
Assign Member group to user if no groups assigned

### DIFF
--- a/src/app/Http/Controllers/Api/MinecraftAuthTokenController.php
+++ b/src/app/Http/Controllers/Api/MinecraftAuthTokenController.php
@@ -91,9 +91,9 @@ final class MinecraftAuthTokenController extends ApiController
         // to the Member group because that's the default non-Guest group
         $groups = $existingPlayer->account->groups;
         if (count($groups) === 0) {
-            $memberGroup = Group::where('name', 'member')->first();
-            $existingPlayer->account->groups()->attach($memberGroup->getKey());
-            $existingPlayer->account->groups->push($memberGroup);
+            $defaultGroups = Group::where('is_default', 1)->get()->pluck('group_id');
+            $existingPlayer->account->groups()->attach($defaultGroups);
+            $existingPlayer->account->groups->push($defaultGroups);
         }
         
         return [


### PR DESCRIPTION
## Overview of Changes
When using the Minecraft auth `show` route, assigns the `Member` group to the user if they have an account but for some reason have no groups assigned