### PR TITLE
Add command to assign all users to default groups if necessary

### DIFF
--- a/src/app/Console/Commands/RepairMissingGroupsCommand.php
+++ b/src/app/Console/Commands/RepairMissingGroupsCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Entities\Accounts\Models\Account;
+use Illuminate\Support\Facades\DB;
+
+final class RepairMissingGroupsCOmmand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'groups:assign';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Finds any accounts without a group assigned, and assigns them to the default groups';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $accountsWithoutGroups = Account::doesntHave('groups')->get();
+        $defaultGroups = Group::where('is_default', 1)->get();
+
+        $progressBar = $this->output->createProgressBar(count($accountsWithoutGroups));
+        $progressBar->start();
+     
+        DB::transaction(function() use($accountsWithoutGroups, &$progressBar) {
+            foreach ($accountsWithoutGroups as $account) {
+                $account->groups()->attach($defaultGroups->pluck('group_id'));
+                $progressBar->advance();
+            }
+        });
+
+        $this->info(count($accountsWithoutGroups) . ' accounts assigned to a default group');
+
+        $progressBar->finish();
+    }
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -7,6 +7,7 @@ use App\Console\Commands\QueryServerCommand;
 use App\Entities\Environment;
 use App\Console\Commands\ServerKeyCreateCommand;
 use App\Console\Commands\StripUUIDHyphensCommand;
+use App\Console\Commands\RepairMissingGroupsCOmmand;
 
 class Kernel extends ConsoleKernel
 {
@@ -20,6 +21,7 @@ class Kernel extends ConsoleKernel
         QueryServerCommand::class,
         ServerKeyCreateCommand::class,
         StripUUIDHyphensCommand::class,
+        RepairMissingGroupsCOmmand::class,
     ];
 
     /**

--- a/src/app/Http/Controllers/Api/MinecraftAuthTokenController.php
+++ b/src/app/Http/Controllers/Api/MinecraftAuthTokenController.php
@@ -87,14 +87,8 @@ final class MinecraftAuthTokenController extends ApiController
             throw new UnauthorisedException('account_not_linked', 'This UUID has not been linked to a PCB account. Please complete the authorization flow first');
         }
 
-        // If for some reason the user has no groups but has an account, assign them
-        // to the Member group because that's the default non-Guest group
-        $groups = $existingPlayer->account->groups;
-        if (count($groups) === 0) {
-            $defaultGroups = Group::where('is_default', 1)->get();
-            $existingPlayer->account->groups()->attach($defaultGroups->pluck('group_id'));
-            $existingPlayer->account->groups->push($defaultGroups);
-        }
+        // Force load groups
+        $existingPlayer->account->groups;
         
         return [
             'data' => new AccountResource($existingPlayer->account),


### PR DESCRIPTION
## Overview of Changes
Adds command to find all users without a group and assigns them to the default groups


## Additional Information
### Deployment Steps (Optional)
Run `php artisan groups:assign`