### PR TITLE
Change panel access to new column

### DIFF
--- a/src/app/Entities/Accounts/Models/Account.php
+++ b/src/app/Entities/Accounts/Models/Account.php
@@ -111,6 +111,11 @@ final class Account extends Authenticatable
         return $this->groups()->where('is_admin', true)->count() > 0;
     }
 
+    public function canAccessPanel()
+    {
+        return $this->groups()->where('can_access_panel', true)->count() > 0;
+    }
+
     public function discourseGroupString()
     {
         $groups = $this->groups->pluck("discourse_name");

--- a/src/app/Entities/Groups/Models/Group.php
+++ b/src/app/Entities/Groups/Models/Group.php
@@ -26,7 +26,8 @@ final class Group extends Model
         'is_default',
         'is_staff',
         'is_admin',
-        'discourse_name'
+        'discourse_name',
+        'can_access_panel'
     ];
 
     /**

--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use App\Http\Middleware\AdminOnly;
+use App\Http\Middleware\PanelAccess;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
@@ -61,7 +62,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'admin' => AdminOnly::class
+        'panel' => PanelAccess::class
     ];
 
     /**

--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -76,7 +76,7 @@ class Kernel extends HttpKernel
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \App\Http\Middleware\Authenticate::class,
-        AdminOnly::class,
+        PanelAccess::class,
         \Illuminate\Session\Middleware\AuthenticateSession::class,
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
         \Illuminate\Auth\Middleware\Authorize::class,

--- a/src/app/Http/Middleware/PanelAccess.php
+++ b/src/app/Http/Middleware/PanelAccess.php
@@ -5,7 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Support\Facades\Auth;
 
-class AdminOnly
+class PanelAccess
 {
     /**
      * Handle an incoming request.
@@ -16,7 +16,7 @@ class AdminOnly
      */
     public function handle($request, Closure $next)
     {
-        if (!Auth::check() || !$request->user()->isAdmin()) {
+        if (!Auth::check() || !$request->user()->canAccessPanel()) {
             return abort(403);
         }
 

--- a/src/database/migrations/2020_03_22_113534_add_panel_access_column_to_groups.php
+++ b/src/database/migrations/2020_03_22_113534_add_panel_access_column_to_groups.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPanelAccessColumnToGroups extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->boolean('can_access_panel')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn('can_access_panel');
+        });
+    }
+}

--- a/src/resources/sass/components/_button.scss
+++ b/src/resources/sass/components/_button.scss
@@ -8,6 +8,7 @@
     &:hover {
         background: lighten($colour, 5%);
         border-color: $colour;
+        color: #fff;
     }
     &:active,
     &:focus {
@@ -64,7 +65,7 @@ button.button {
     &--primary {
         @include button-colour($colour-primary, 10%);
     }
-    
+
     &--secondary {
         @include button-colour($colour-secondary);
     }
@@ -72,7 +73,7 @@ button.button {
     &--accent {
         @include button-colour($colour-accent, 3%);
     }
-    
+
     &--large {
         padding: 1em 2em;
     }

--- a/src/resources/views/front/pages/panel/account/show.blade.php
+++ b/src/resources/views/front/pages/panel/account/show.blade.php
@@ -91,10 +91,11 @@
 
         <div class="card">
             <div class="card__body">
-                <form action="{{ route('front.panel.accounts.force-discourse-sync', $account) }}" method="post">
+                <form action="{{ route('front.panel.accounts.force-discourse-sync', $account) }}" method="post" style="display:inline;">
                     @csrf
                     <button type="submit" class="button button--primary">SSO Sync</button>
                 </form>
+                <a href="{{ route('front.panel.accounts.discourse-admin-redirect', $account) }}" class="button button--primary">Forum Admin</a>
             </div>
         </div>
 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -163,7 +163,7 @@ Route::group(['middleware' => 'auth'], function() {
 
 Route::get('bans', 'BanlistController@index')->name('front.banlist');
 
-Route::group(['prefix' => 'panel', 'as' => 'front.panel.', 'namespace' => 'Panel', 'middleware' => 'admin'], function() {
+Route::group(['prefix' => 'panel', 'as' => 'front.panel.', 'namespace' => 'Panel', 'middleware' => 'panel'], function() {
     Route::view('/', 'front.pages.panel');
 
     Route::resource('accounts', 'AccountController')->only(['index', 'show', 'edit', 'update']);

--- a/src/tests/Feature/PanelAccountListTest.php
+++ b/src/tests/Feature/PanelAccountListTest.php
@@ -18,7 +18,7 @@ class PanelAccountListTest extends TestCase
         $this->adminAccount = factory(Account::class)->create();
         $adminGroup = Group::create([
             'name' => 'Administrator',
-            'is_admin' => true
+            'can_access_panel' => true
         ]);
 
         $this->adminAccount->groups()->attach($adminGroup->group_id);

--- a/src/tests/Feature/PanelAccountTest.php
+++ b/src/tests/Feature/PanelAccountTest.php
@@ -24,7 +24,7 @@ class PanelAccountTest extends TestCase
         $this->adminAccount = factory(Account::class)->create();
         $adminGroup = Group::create([
             'name' => 'Administrator',
-            'is_admin' => true
+            'can_access_panel' => true
         ]);
 
         $this->adminAccount->groups()->attach($adminGroup->group_id);

--- a/src/tests/Feature/PanelDonationsListTest.php
+++ b/src/tests/Feature/PanelDonationsListTest.php
@@ -20,7 +20,7 @@ class PanelDonationsListTest extends TestCase
         $this->adminAccount = factory(Account::class)->create();
         $adminGroup = Group::create([
             'name' => 'Administrator',
-            'is_admin' => true
+            'can_access_panel' => true
         ]);
 
         $this->adminAccount->groups()->attach($adminGroup->group_id);


### PR DESCRIPTION
## Overview of Changes
- The panel access middleware now uses a new column `can_access_panel` on the groups table for permissions

## Additional Information
### Deployment Steps (Optional)
- Go in the DB and give SOPs and Admins `can_access_panel`
