### PR TITLE
Fix headers not being sent to Discourse API

### DIFF
--- a/src/app/Library/Discourse/Api/DiscourseAdminApi.php
+++ b/src/app/Library/Discourse/Api/DiscourseAdminApi.php
@@ -35,7 +35,7 @@ class DiscourseAdminApi extends DiscourseAPIRequest
     {
         $response = $this->client->get('admin/users/list/all.json', [
             'query' => [
-                'email'         => $email,
+                'email' => $email,
             ],
         ]);
 
@@ -75,8 +75,8 @@ class DiscourseAdminApi extends DiscourseAPIRequest
 
         $response = $this->client->post('admin/users/sync_sso', [
             'query' => [
-                'sso'           => $payload,
-                'sig'           => $signature
+                'sso' => $payload,
+                'sig' => $signature
             ],
         ]);
 

--- a/src/app/Library/Discourse/Api/DiscourseClient.php
+++ b/src/app/Library/Discourse/Api/DiscourseClient.php
@@ -20,12 +20,10 @@ final class DiscourseClient extends Client
     {
         parent::__construct([
             'base_uri' => 'https://forums.projectcitybuild.com/',
-            [
-                'headers' => [
-                    'Api-Key' => $this->getApiKey(),
-                    'Api-User' => $this->getApiUser()
-                ]
-            ]
+            'headers' => [
+                'Api-Key' => $this->getApiKey(),
+                'Api-Username' => $this->getApiUser()
+            ],
         ]);
     }
 }


### PR DESCRIPTION
## Overview of Changes
* Changes `Api-User` header key to `Api-Username` (thanks @freddyheppell)
* Fixes headers not being sent to Discourse API in requests

## Additional Information
### Deployment Steps (Optional)
None

### Screenshots (Optional)
|Before|After|
|--|--|
|||