### PR TITLE
Improve Signup Flow

### DIFF
--- a/src/app/Entities/Accounts/Models/Account.php
+++ b/src/app/Entities/Accounts/Models/Account.php
@@ -5,6 +5,7 @@ namespace App\Entities\Accounts\Models;
 use App\Entities\Donations\Models\Donation;
 use App\Entities\Donations\Models\DonationPerk;
 use App\Model;
+use Carbon\Carbon;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\URL;
@@ -148,5 +149,12 @@ final class Account extends Authenticatable
         return URL::temporarySignedRoute('front.register.activate', now()->addDay(), [
             'email' => $this->email,
         ]);
+    }
+
+    public function updateLastLogin($ip)
+    {
+        $this->last_login_ip = $ip;
+        $this->last_login_at = Carbon::now();
+        $this->save();
     }
 }

--- a/src/app/Http/Controllers/LoginController.php
+++ b/src/app/Http/Controllers/LoginController.php
@@ -5,13 +5,18 @@ namespace App\Http\Controllers;
 use App\Library\Discourse\Api\DiscourseAdminApi;
 use App\Entities\Accounts\Repositories\AccountRepository;
 use App\Library\Discourse\Exceptions\UserNotFound;
+use App\Library\RateLimit\Storage\SessionTokenStorage;
+use App\Library\RateLimit\TokenBucket;
+use App\Library\RateLimit\TokenRate;
 use App\Services\Login\LogoutService;
 use App\Http\Requests\LoginRequest;
 use App\Http\WebController;
 use Carbon\Carbon;
-use Illuminate\Contracts\Auth\Guard as Auth;
+use Illuminate\Contracts\Auth\Guard as AuthGuard;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 final class LoginController extends WebController
 {
@@ -31,7 +36,7 @@ final class LoginController extends WebController
     private $logoutService;
 
     /**
-     * @var Auth
+     * @var AuthGuard
      */
     private $auth;
 
@@ -40,8 +45,9 @@ final class LoginController extends WebController
         DiscourseAdminApi $discourseAdminApi,
         AccountRepository $accountRepository,
         LogoutService $logoutService,
-        Auth $auth
-    ) {
+        AuthGuard $auth
+    )
+    {
         $this->discourseAdminApi = $discourseAdminApi;
         $this->accountRepository = $accountRepository;
         $this->logoutService = $logoutService;
@@ -55,11 +61,35 @@ final class LoginController extends WebController
 
     public function store(LoginRequest $request)
     {
-        $account  = $this->auth->user();
+        $refillRate = TokenRate::refill(3)->every(2, TokenRate::MINUTES);
+        $sessionStorage = new SessionTokenStorage('login.rate', 5);
+        $rateLimit = new TokenBucket(6, $refillRate, $sessionStorage);
 
-        $account->last_login_ip = $request->ip();
-        $account->last_login_at = Carbon::now();
-        $account->save();
+        if ($rateLimit->consume(1) === false) {
+            throw ValidationException::withMessages([
+                'error' => ['Too many login attempts. Please try again in a few minutes'],
+            ]);
+        }
+
+        if (!Auth::attempt($request->validated())) {
+            $triesLeft = floor($rateLimit->getAvailableTokens());
+
+            throw ValidationException::withMessages([
+                'error' => ['Email or password is incorrect: ' . $triesLeft . ' attempts remaining'],
+            ]);
+        }
+
+        if (!$this->auth->user()->activated) {
+            Auth::logout();
+
+            throw ValidationException::withMessages([
+                'error' => ['Your email has not been confirmed. If you didn\'t receive it, check your spam. If you need help, ask PCB staff.']
+            ]);
+        }
+
+        $account = $this->auth->user();
+        
+        $account->updateLastLogin($request->ip());
 
         // Set the user's nickname from Discourse if it isn't already
         if ($account->username == null) {

--- a/src/app/Http/Controllers/LoginController.php
+++ b/src/app/Http/Controllers/LoginController.php
@@ -88,7 +88,7 @@ final class LoginController extends WebController
         }
 
         $account = $this->auth->user();
-        
+
         $account->updateLastLogin($request->ip());
 
         // Set the user's nickname from Discourse if it isn't already

--- a/src/app/Http/Controllers/RegisterController.php
+++ b/src/app/Http/Controllers/RegisterController.php
@@ -62,9 +62,9 @@ final class RegisterController extends WebController
             $request->ip()
         );
 
-        if ($request->cookies->has('intended')) {
-            $intended = $request->cookies->get('intended');
-            $request->cookies->remove('intended');
+        if ($request->session()->has('url.intended')) {
+            $intended = $request->session()->get('url.intended');
+            $request->session()->remove('intended');
             return redirect($intended);
         }
 

--- a/src/app/Http/Requests/LoginRequest.php
+++ b/src/app/Http/Requests/LoginRequest.php
@@ -24,49 +24,6 @@ final class LoginRequest extends FormRequest
         ];
     }
 
-    /**
-     * Configure the validator instance.
-     *
-     * @param  \Illuminate\Validation\Validator  $validator
-     * @return void
-     */
-    public function withValidator($validator)
-    {
-        if ($validator->failed()) {
-            return;
-        }
-
-        $refillRate = TokenRate::refill(3)->every(2, TokenRate::MINUTES);
-        $sessionStorage = new SessionTokenStorage('login.rate', 5);
-        $rateLimit = new TokenBucket(6, $refillRate, $sessionStorage);
-
-        $validator->after(function ($validator) use ($rateLimit) {
-            if ($rateLimit->consume(1) === false) {
-                $validator->errors()->add('error', 'Too many login attempts. Please try again in a few minutes');
-            }
-        });
-
-        $validator->after(function ($validator) use ($rateLimit) {
-            $input      = $validator->getData();
-            $email      = $input['email'];
-            $password   = $input['password'];
-
-            $credentials = [
-                'email'     => $email,
-                'password'  => $password,
-                'activated' => true
-            ];
-
-            if (Auth::attempt($credentials, true) === false) {
-                if (Account::where('email', $email)->exists()) {
-                    $validator->errors()->add('error', 'You need to verify your email address. If you haven\'t got the verification email, ask staff for help.');
-                }
-                // Authentication has failed
-                $triesLeft = floor($rateLimit->getAvailableTokens());
-                $validator->errors()->add('error', 'Email or password is incorrect: '.$triesLeft.' attempts remaining');
-            }
-        });
-    }
 
     /**
      * Determine if the user is authorized to make this request.

--- a/src/app/Http/Requests/LoginRequest.php
+++ b/src/app/Http/Requests/LoginRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Entities\Accounts\Models\Account;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Library\RateLimit\TokenRate;
@@ -57,6 +58,9 @@ final class LoginRequest extends FormRequest
             ];
 
             if (Auth::attempt($credentials, true) === false) {
+                if (Account::where('email', $email)->exists()) {
+                    $validator->errors()->add('error', 'You need to verify your email address. If you haven\'t got the verification email, ask staff for help.');
+                }
                 // Authentication has failed
                 $triesLeft = floor($rateLimit->getAvailableTokens());
                 $validator->errors()->add('error', 'Email or password is incorrect: '.$triesLeft.' attempts remaining');

--- a/src/config/sentry.php
+++ b/src/config/sentry.php
@@ -4,7 +4,7 @@ return array(
     'dsn' => env('SENTRY_DSN'),
 
     // capture release as git sha
-    'release' => trim(exec('git log --pretty="%h" -n1 HEAD')),
+    'release' => \App\Entities\Environment::isProduction() ? trim(exec('git log --pretty="%h" -n1 HEAD')) : 'NON_PRODUCTION',
 
     // Capture bindings on SQL queries
     'breadcrumbs.sql_bindings' => true,

--- a/src/resources/views/front/pages/login/login.blade.php
+++ b/src/resources/views/front/pages/login/login.blade.php
@@ -9,17 +9,11 @@
         <div class="login__left">
             <h1>Sign In to PCB</h1>
 
-            <small>
-                <i class="fas fa-exclamation-circle"></i> 
-                Notice: Anyone with a forum account before we moved to Discourse <a href="{{ route('front.password-reset.create') }}">must reset their password first</a>!
-                <p />
-                See <a href="https://forums.projectcitybuild.com/t/welcome-to-the-new-forums/32708/1" target="_blank">this post</a> for more details.
-            </small>
             <br>
 
             <form method="post" action="{{ route('front.login.submit') }}">
                 @csrf
-                
+
                 @if($errors->any())
                     <div class="alert alert--error">
                         <h3><i class="fas fa-exclamation-circle"></i> Error</h3>
@@ -56,11 +50,11 @@
             <div class="login__description">
                 Members gain access to personal player statistics, the forums, in-game rank synchronization and more.
             </div>
-            
+
             <a class="button button--fill button--large button--accent" href="{{ route('front.register') }}">
                 Create an Account
             </a>
-            
+
             <!-- <div class="login__divider">or</div>
 
             <div class="login__social">

--- a/src/resources/views/front/pages/register/register-success.blade.php
+++ b/src/resources/views/front/pages/register/register-success.blade.php
@@ -7,11 +7,9 @@
 
     <div class="card">
         <div class="card__body card__body--padded">
-            <h1>Thank you for registering. Please verify your account</h1>
+            <h1>Please verify your email</h1>
             <p>
-                In order to complete your registration, you must verify your account.
-                An email has been sent to you with a link to do so. 
-                If you have not received the email after a few minutes, please check your spam folder.
+                To finish registering, please confirm your email address. If it doesn't arrive in a few minutes, try checking spam.
             </p>
         </div>
 

--- a/src/tests/Feature/LoginTest.php
+++ b/src/tests/Feature/LoginTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature;
 use App\Entities\Accounts\Models\Account;
 use App\Library\Discourse\Api\DiscourseAdminApi;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
 
 class LoginTest extends TestCase

--- a/src/tests/Feature/LoginTest.php
+++ b/src/tests/Feature/LoginTest.php
@@ -95,4 +95,20 @@ class LoginTest extends TestCase
         ])
             ->assertRedirect(route('front.account.settings'));
     }
+
+    public function testLastLoginDetailsUpdated()
+    {
+        $oldLoginTime = $this->account->last_login_at;
+        $oldLoginIp = $this->account->last_login_ip;
+
+        $this->post(route('front.login.submit'), [
+            'email' => $this->account->email,
+            'password' => "secret"
+        ])->assertSessionHasNoErrors();
+
+        $this->account->refresh();
+
+        $this->assertNotEquals($oldLoginIp, $this->account->last_login_ip);
+        $this->assertNotEquals($oldLoginTime, $this->account->last_login_at);
+    }
 }


### PR DESCRIPTION
## Overview of Changes
* Fix logic to redirect users back to intent when email is verified
* Explicit warning for users if they try to log in with an unactivated account (as part of this I moved the login logic out of the request and into the controller, raising ValidationExceptions where applicable, which is how Laravel's default does this)
* More tests!